### PR TITLE
Setpoint test

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You must have the ESP01 Module installed and flash it with https://github.com/je
 Baudrate 115200, 8N1.
 Pin layout is mentioned in the pdf (pcb, J8)
 
+Optionally one can use the Wemos D1 flashed with espeasy (https://www.letscontrolit.com/wiki/index.php/ESPEasy). This device has a 5V input and integrated CH340 for easy flashing. The only tweak I needed was to add 5ms timeout delay in the serial device settings of espeasy to get robust data from my pellet stove ( Duroflame Rembrand). In Esp_easy flashed device select the Device: Communication - Serial Server (https://www.letscontrolit.com/wiki/index.php?title=Ser2Net) and fill in the appropiate fields (harware serial GPIO-3 and -1, port 1234 (or any) baud rate 115200, serial config 8N1,RX receive 5ms, 256 buffer). 
+
 ## Functionality
 - Control target temperature.
 - Control system on/off.

--- a/custom_components/duepi_evo/climate.py
+++ b/custom_components/duepi_evo/climate.py
@@ -210,7 +210,7 @@ class DuepiEvoDevice(ClimateEntity):
         self._current_temperature = data[1]
         self._fan_mode = data[2]
         if support_setpoint == True:
-            self._fan_mode = data[3]
+            self._target_temperature = data[3]
 
         self._heating = True
         self._hvac_mode = HVAC_MODE_HEAT


### PR DESCRIPTION
Can you try this?

This seems to work for me now...it ignores the setpoint when it returns 0
2023-03-16 13:39:35.759 DEBUG (MainThread) [custom_components.duepi_evo.climate] Pellet stove: Received burner: Off, Ambient temp: 20.8, Fan speed: 0
2023-03-16 13:39:35.773 DEBUG (MainThread) [custom_components.duepi_evo.climate] **Pellet stove Setpoint retrieval not supported by this stove, using _current_temperature 20 /**
2023-03-16 13:39:58.383 DEBUG (MainThread) [custom_components.duepi_evo.climate] Pellet stove: Set target temp to 22.0°C